### PR TITLE
update to latest inline-source, remove support for missing input file argument

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,5 +21,5 @@ inline-source --compress false --root ./ file.html
 ... or using pipes:
 
 ```sh
-cat build/index.html | inline-source --root build > build/bundle.html
+cat build/index.html | inline-source --root build - > build/bundle.html
 ```

--- a/README.md
+++ b/README.md
@@ -13,7 +13,30 @@ npm install inline-source-cli
 
 
 ## Usage
+```
+inline-source <input> [output]
 
+inline and compress tags that contain the inline attribute.
+supports <script>, <link>, and <img> (including *.svg sources) tags
+
+Positionals:
+  input   (required) input html filename, or - to read from standard input
+                                                                        [string]
+  output  (optional) output html filename, or write to standard output if
+          omitted                                                       [string]
+
+Options:
+  --version               Show version number                          [boolean]
+  --compress, -z          enable/disable compression of inlined content.
+                                                       [boolean] [default: true]
+  --attribute, -a         attribute used to parse sources. all tags will be
+                          parsed if set to false.   [string] [default: "inline"]
+  --rootpath, -d, --root  directory path used for resolving inlineable paths.
+                          default: process.cwd()                        [string]
+  --help                  Show help                                    [boolean]
+```
+
+process HTML from 'file.html' and output to stdout:
 ```sh
 inline-source --compress false --root ./ file.html
 ```

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "inline-source-cli",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "CLI for inline-source",
   "main": "dist/index.js",
   "bin": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "inline-source-cli",
-  "version": "1.2.1",
+  "version": "2.0.0",
   "description": "CLI for inline-source",
   "main": "dist/index.js",
   "bin": {
@@ -18,10 +18,10 @@
     "url": "git://github.com/developit/inline-source-cli.git"
   },
   "devDependencies": {
-    "babel-cli": "^6.5.1",
-    "babel-eslint": "^5.0.0",
-    "babel-preset-es2015": "^6.5.0",
-    "eslint": "^2.2.0",
+    "babel-cli": "^6.26.0",
+    "babel-eslint": "^8.2.1",
+    "babel-preset-es2015": "^6.24.1",
+    "eslint": "^4.17.0",
     "mkdirp": "^0.5.1"
   },
   "bugs": {
@@ -37,7 +37,8 @@
   "author": "Jason Miller <jason@developit.ca>",
   "license": "MIT",
   "dependencies": {
-    "inline-source": "^5.0.0",
-    "yargs": "^4.1.0"
+    "inline-source": "^6.1.1",
+    "rw": "^1.3.3",
+    "yargs": "^11.0.0"
   }
 }


### PR DESCRIPTION
remove support for missing input file argument to avoid ambiguous case without input file arg but with output file arg. the input file argument is mandatory, but can be set to - (dash) to process from standard input.

additional modifications:
* update all dependencies
* refactor with [rw](https://npmjs.com/package/rw)
* enhance help through yarn and add detailed usage (--help output) to README
