### PR TITLE
Update all deps to fix all CVE's

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,3 +1,11 @@
 {
-  "presets": ["es2015"]
+  "presets": [
+    [
+      "env", {
+        "targets": {
+            "node": "7.6"
+        }
+      }
+    ]
+  ]
 }

--- a/.babelrc
+++ b/.babelrc
@@ -1,9 +1,10 @@
 {
   "presets": [
     [
-      "env", {
+      "@babel/preset-env",
+      {
         "targets": {
-            "node": "7.6"
+          "node": "7.6"
         }
       }
     ]

--- a/.babelrc
+++ b/.babelrc
@@ -4,7 +4,7 @@
       "@babel/preset-env",
       {
         "targets": {
-          "node": "7.6"
+          "node": "8"
         }
       }
     ]

--- a/.eslintrc
+++ b/.eslintrc
@@ -4,8 +4,10 @@
   "env": {
     "node": true
   },
-  "ecmaFeatures": {
-    "modules": true
+  "parserOptions": {
+    "ecmaFeatures": {
+      "modules": true
+    }
   },
   "rules": {
     "no-unused-vars": [1, { "args": "after-used" }],

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 dist
 npm-debug.log
 node_modules
+test/out/foo.html

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,3 +2,4 @@ language: node_js
 node_js:
   - lts/*
   - node
+  - 7.6

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,4 +2,4 @@ language: node_js
 node_js:
   - lts/*
   - node
-  - 7.6
+  - 8

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
 language: node_js
 node_js:
-  - lts/8
+  - lts/*
   - node

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,1 +1,4 @@
 language: node_js
+node_js:
+  - lts/8
+  - node

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "inline-source-cli",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "description": "CLI for inline-source",
   "main": "dist/index.js",
   "bin": {
@@ -20,11 +20,12 @@
     "url": "git://github.com/developit/inline-source-cli.git"
   },
   "devDependencies": {
-    "babel-cli": "^6.5.1",
-    "babel-eslint": "^5.0.0",
-    "babel-preset-es2015": "^6.5.0",
+    "@babel/cli": "^7.6.2",
+    "@babel/core": "^7.6.2",
+    "babel-eslint": "^10.0.3",
+    "babel-preset-env": "^1.7.0",
     "chai": "^4.2.0",
-    "eslint": "^2.2.0",
+    "eslint": "^6.5.1",
     "mkdirp": "^0.5.1",
     "mocha": "^6.2.0"
   },

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
   "scripts": {
     "build": "babel src -d dist -s",
     "prebuild": "mkdirp dist",
-    "test": "eslint src",
+    "lint": "eslint src",
+    "test": "mocha",
     "prepublish": "npm run build",
     "release": "npm run build && git commit -am $npm_package_version && git tag $npm_package_version && git push && git push --tags && npm publish"
   },
@@ -21,8 +22,10 @@
     "babel-cli": "^6.5.1",
     "babel-eslint": "^5.0.0",
     "babel-preset-es2015": "^6.5.0",
+    "chai": "^4.2.0",
     "eslint": "^2.2.0",
-    "mkdirp": "^0.5.1"
+    "mkdirp": "^0.5.1",
+    "mocha": "^6.2.0"
   },
   "bugs": {
     "url": "https://github.com/developit/inline-source-cli"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "inline-source-cli",
-  "version": "1.2.0",
+  "version": "2.0.0",
   "description": "CLI for inline-source",
   "main": "dist/index.js",
   "bin": {
@@ -10,7 +10,7 @@
     "build": "babel src -d dist -s",
     "prebuild": "mkdirp dist",
     "lint": "eslint src",
-    "test": "mocha",
+    "test": "mocha --timeout 5000",
     "prepublish": "npm run build",
     "release": "npm run build && git commit -am $npm_package_version && git tag $npm_package_version && git push && git push --tags && npm publish"
   },
@@ -40,7 +40,7 @@
   "author": "Jason Miller <jason@developit.ca>",
   "license": "MIT",
   "dependencies": {
-    "inline-source": "^5.0.0",
+    "inline-source": "^7.1.0",
     "yargs": "^4.1.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "inline-source-cli",
-  "version": "2.1.0",
+  "version": "1.2.0",
   "description": "CLI for inline-source",
   "main": "dist/index.js",
   "bin": {
@@ -43,6 +43,6 @@
   "license": "MIT",
   "dependencies": {
     "inline-source": "^7.1.0",
-    "yargs": "^14.0.0"
+    "yargs": "^14.2.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "lint": "eslint src",
     "pretest": "mkdirp test/out",
     "test": "mocha --timeout 5000",
-    "prepublish": "npm run build",
+    "prepare": "npm run build",
     "release": "npm run build && git commit -am $npm_package_version && git tag $npm_package_version && git push && git push --tags && npm publish"
   },
   "repository": {

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "build": "babel src -d dist -s",
     "prebuild": "mkdirp dist",
     "lint": "eslint src",
+    "pretest": "mkdirp test/out",
     "test": "mocha --timeout 5000",
     "prepublish": "npm run build",
     "release": "npm run build && git commit -am $npm_package_version && git tag $npm_package_version && git push && git push --tags && npm publish"

--- a/package.json
+++ b/package.json
@@ -43,6 +43,6 @@
   "license": "MIT",
   "dependencies": {
     "inline-source": "^7.1.0",
-    "yargs": "^4.1.0"
+    "yargs": "^14.0.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -22,8 +22,8 @@
   "devDependencies": {
     "@babel/cli": "^7.6.2",
     "@babel/core": "^7.6.2",
+    "@babel/preset-env": "^7.0.0",
     "babel-eslint": "^10.0.3",
-    "babel-preset-env": "^1.7.0",
     "chai": "^4.2.0",
     "eslint": "^6.5.1",
     "mkdirp": "^0.5.1",

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 
-import inline from 'inline-source';
+import {inlineSource} from 'inline-source';
 import yargs from 'yargs';
 import fs from 'fs';
 
@@ -36,17 +36,13 @@ else {
 	run(source, argv);
 }
 
-function run(source, argv) {
-	inline(source, {
-		compress: argv.compress,
-		rootpath: argv.root || argv.rootpath || process.cwd(),
-		attribute: argv.attribute
-	}, (err, html) => {
-		if (err) {
-			process.stderr.write(`Error: ${err}\n`);
-			return process.exit(1);
-		}
-
+async function run(source, argv) {
+	try {
+		const html = await inlineSource(source, {
+			compress: argv.compress,
+			rootpath: argv.root || argv.rootpath || process.cwd(),
+			attribute: argv.attribute
+		});
 		let out = argv._[1];
 		if (out) {
 			fs.writeFile(out, html, err => {
@@ -63,5 +59,8 @@ function run(source, argv) {
 			process.stdout.write(html + '\n');
 			process.exit(0);
 		}
-	});
+	} catch (err) {
+		process.stderr.write(`Error: ${err}\n`);
+		return process.exit(1);
+	}
 }

--- a/test/fixtures/foo.html
+++ b/test/fixtures/foo.html
@@ -1,0 +1,1 @@
+<script inline src="./foo.js"></script>

--- a/test/fixtures/foo.js
+++ b/test/fixtures/foo.js
@@ -1,0 +1,2 @@
+var foo = this;
+console.log(foo);

--- a/test/index.js
+++ b/test/index.js
@@ -1,26 +1,29 @@
 'use strict';
 
 const { expect } = require('chai');
-const util = require('util');
-const exec = util.promisify(require('child_process').exec);
-const readFile = util.promisify(require('fs').readFile);
+const exec = require('child_process').exec;
+const readFile = require('fs').readFile;
 
 describe('Inline Source CLI', () => {
-  it('should inline the file properly', async () => {
-    await exec('node dist/index.js test/fixtures/foo.html test/out/foo.html');
-    // check the file
-    const data = await readFile('test/out/foo.html', 'utf8');
-    expect(data).to.equal(
-      '<script>var foo = this;\nconsole.log(foo);\n</script>\n'
-    );
+  it('should inline the file properly', (done) => {
+    exec('node dist/index.js test/fixtures/foo.html test/out/foo.html', (err, stdout, stderr) => {
+      readFile('test/out/foo.html', 'utf8', (err, data) => {
+        expect(data).to.equal(
+          '<script>var foo = this;\nconsole.log(foo);\n</script>\n'
+        );
+        done();
+      });
+    });
   });
 
-  it('should inline and compress the file properly', async () => {
-    await exec('node dist/index.js --compress test/fixtures/foo.html test/out/foo.html');
-    // check the file
-    const data = await readFile('test/out/foo.html', 'utf8');
-    expect(data).to.equal(
-      '<script>var foo=this;console.log(foo);</script>\n'
-    );
+  it('should inline and compress the file properly', (done) => {
+    exec('node dist/index.js --compress test/fixtures/foo.html test/out/foo.html', (err, stdout, stderr) => {
+      readFile('test/out/foo.html', 'utf8', (err, data) => {
+        expect(data).to.equal(
+          '<script>var foo=this;console.log(foo);</script>\n'
+        );
+        done();
+      });
+    });
   });
 });

--- a/test/index.js
+++ b/test/index.js
@@ -1,0 +1,26 @@
+'use strict';
+
+const { expect } = require('chai');
+const util = require('util');
+const exec = util.promisify(require('child_process').exec);
+const readFile = util.promisify(require('fs').readFile);
+
+describe('Inline Source CLI', () => {
+  it('should inline the file properly', async () => {
+    await exec('node dist/index.js test/fixtures/foo.html test/out/foo.html');
+    // check the file
+    const data = await readFile('test/out/foo.html', 'utf8');
+    expect(data).to.equal(
+      '<script>var foo = this;\nconsole.log(foo);\n</script>\n'
+    );
+  });
+
+  it('should inline and compress the file properly', async () => {
+    await exec('node dist/index.js --compress test/fixtures/foo.html test/out/foo.html');
+    // check the file
+    const data = await readFile('test/out/foo.html', 'utf8');
+    expect(data).to.equal(
+      '<script>var foo=this;console.log(foo);</script>\n'
+    );
+  });
+});

--- a/test/index.js
+++ b/test/index.js
@@ -1,29 +1,26 @@
 'use strict';
 
 const { expect } = require('chai');
-const exec = require('child_process').exec;
-const readFile = require('fs').readFile;
+const util = require('util');
+const exec = util.promisify(require('child_process').exec);
+const readFile = util.promisify(require('fs').readFile);
 
 describe('Inline Source CLI', () => {
-  it('should inline the file properly', (done) => {
-    exec('node dist/index.js test/fixtures/foo.html test/out/foo.html', (err, stdout, stderr) => {
-      readFile('test/out/foo.html', 'utf8', (err, data) => {
-        expect(data).to.equal(
-          '<script>var foo = this;\nconsole.log(foo);\n</script>\n'
-        );
-        done();
-      });
-    });
+  it('should inline the file properly', async () => {
+    await exec('node dist/index.js test/fixtures/foo.html test/out/foo.html');
+    // check the file
+    const data = await readFile('test/out/foo.html', 'utf8');
+    expect(data).to.equal(
+      '<script>var foo = this;\nconsole.log(foo);\n</script>\n'
+    );
   });
 
-  it('should inline and compress the file properly', (done) => {
-    exec('node dist/index.js --compress test/fixtures/foo.html test/out/foo.html', (err, stdout, stderr) => {
-      readFile('test/out/foo.html', 'utf8', (err, data) => {
-        expect(data).to.equal(
-          '<script>var foo=this;console.log(foo);</script>\n'
-        );
-        done();
-      });
-    });
+  it('should inline and compress the file properly', async () => {
+    await exec('node dist/index.js --compress test/fixtures/foo.html test/out/foo.html');
+    // check the file
+    const data = await readFile('test/out/foo.html', 'utf8');
+    expect(data).to.equal(
+      '<script>var foo=this;console.log(foo);</script>\n'
+    );
   });
 });


### PR DESCRIPTION
This PR updates all dependencies, fixes all CVE's and brings everything up to date. 

First, I added some tests, then I upgraded inline-source to be the latest version. (see #11).  I then upgraded eslint, babel, and yargs to the latest versions.

Node support is set to 7.6, the same as inline-source.